### PR TITLE
Improve Error Messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +126,12 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "io-lifetimes"
@@ -180,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "mmproxy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "argwerk",
  "cidr",
@@ -188,6 +204,7 @@ dependencies = [
  "libc",
  "log",
  "proxy-protocol",
+ "simple-eyre",
  "socket2",
  "tokio",
 ]
@@ -201,6 +218,12 @@ dependencies = [
  "hermit-abi 0.1.19",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "pin-project-lite"
@@ -265,6 +288,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "simple-eyre"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b561532e8ffe7ecf09108c4f662896a9ec3eac4999eba84015ec3dcb8cc630a"
+dependencies = [
+ "eyre",
+ "indenter",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ cidr = "0.2.1"
 proxy-protocol = "0.5.0"
 socket2 = "0.4.7"
 libc = "0.2.138"
+simple-eyre = "0.3.1"
 
 [dependencies.tokio]
 version = "1.23.0"

--- a/src/listener/tcp.rs
+++ b/src/listener/tcp.rs
@@ -1,10 +1,12 @@
+use simple_eyre::eyre::{Result, WrapErr};
+
 use crate::{
     args::Args,
     pipe::{splice, wouldblock, Pipe, PIPE_BUF_SIZE},
     util,
 };
 
-use std::{io, net::SocketAddr, os::fd::AsRawFd};
+use std::{net::SocketAddr, os::fd::AsRawFd};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt, Interest},
     net::{
@@ -13,26 +15,39 @@ use tokio::{
     },
 };
 
-pub async fn listen(args: Args) -> io::Result<()> {
+pub async fn listen(args: Args) -> Result<()> {
     let socket = match args.listen_addr {
-        SocketAddr::V4(_) => TcpSocket::new_v4()?,
-        SocketAddr::V6(_) => TcpSocket::new_v6()?,
+        SocketAddr::V4(_) => TcpSocket::new_v4(),
+        SocketAddr::V6(_) => TcpSocket::new_v6(),
     };
+    let socket = socket.wrap_err("failed to create socket")?;
 
-    socket.set_reuseport(args.listeners > 1)?;
-    socket.set_reuseaddr(true)?;
-    socket.bind(args.listen_addr)?;
+    socket
+        .set_reuseport(args.listeners > 1)
+        .wrap_err("failed to set reuseport")?;
+    socket
+        .set_reuseaddr(true)
+        .wrap_err("failed to set reuseaddr")?;
+    socket
+        .bind(args.listen_addr)
+        .wrap_err_with(|| format!("failed to bind to {}", args.listen_addr))?;
 
-    let listener = socket.listen(args.listeners)?;
-    log::info!("listening on: {}", listener.local_addr()?);
+    let listener = socket
+        .listen(args.listeners)
+        .wrap_err("failed to start the listener")?;
 
+    log::info!("listening on: {}", args.listen_addr);
     loop {
-        let (conn, addr) = listener.accept().await?;
+        let (conn, addr) = listener
+            .accept()
+            .await
+            .wrap_err("failed to accept connection")?;
+
         if let Some(ref allowed_subnets) = args.allowed_subnets {
             let ip_addr = addr.ip();
 
             if !util::check_origin_allowed(&ip_addr, allowed_subnets) {
-                log::debug!("connection origin is not allowed: {ip_addr}");
+                log::warn!("connection origin is not allowed: {ip_addr}");
                 continue;
             }
         }
@@ -43,7 +58,7 @@ pub async fn listen(args: Args) -> io::Result<()> {
 
         tokio::spawn(async move {
             if let Err(err) = tcp_handle_connection(conn, addr, mark, ipv4_fwd, ipv6_fwd).await {
-                log::error!("while handling a connection: {err}");
+                log::error!("{err:#}");
             }
         });
     }
@@ -55,12 +70,19 @@ async fn tcp_handle_connection(
     mark: u32,
     ipv4_fwd: SocketAddr,
     ipv6_fwd: SocketAddr,
-) -> io::Result<()> {
-    src.set_nodelay(true)?;
-    let mut buffer = [0u8; u16::MAX as usize];
-    let read_bytes = src.read(&mut buffer).await?;
+) -> Result<()> {
+    src.set_nodelay(true)
+        .wrap_err_with(|| format!("failed to set nodelay on {addr} socket"))?;
 
-    let (addr_pair, mut rest, _version) = util::parse_proxy_protocol_header(&buffer[..read_bytes])?;
+    let mut buffer = [0u8; u16::MAX as usize];
+    let read_bytes = src
+        .read(&mut buffer)
+        .await
+        .wrap_err_with(|| format!("failed to read the initial proxy-protocol header on {addr}"))?;
+
+    let (addr_pair, mut rest, _version) = util::parse_proxy_protocol_header(&buffer[..read_bytes])
+        .wrap_err("failed to parse the proxy protocol header")?;
+
     let src_addr = match addr_pair {
         Some((src, _dst)) => src,
         None => {
@@ -72,34 +94,43 @@ async fn tcp_handle_connection(
         SocketAddr::V4(_) => ipv4_fwd,
         SocketAddr::V6(_) => ipv6_fwd,
     };
-    log::info!("[new conn] [origin: {addr} [src: {src_addr}]");
+    log::info!("[new conn] [origin: {addr}] [src: {src_addr}]");
 
     let mut dst = util::tcp_create_upstream_conn(src_addr, target_addr, mark).await?;
-    tokio::io::copy_buf(&mut rest, &mut dst).await?;
+    tokio::io::copy_buf(&mut rest, &mut dst)
+        .await
+        .wrap_err("failed to re-transmit rest of the initial tcp packet")?;
 
     let (mut sr, mut sw) = src.split();
     let (mut dr, mut dw) = dst.split();
 
     let src_to_dst = async {
         splice_copy(&mut sr, &mut dw).await?;
-        dw.shutdown().await
+        dw.shutdown()
+            .await
+            .wrap_err("failed to shutdown the dst writer")
     };
     let dst_to_src = async {
         splice_copy(&mut dr, &mut sw).await?;
-        sw.shutdown().await
+        sw.shutdown()
+            .await
+            .wrap_err("failed to shutdown the src writer")
     };
 
-    tokio::try_join!(src_to_dst, dst_to_src).map(|_| ())
+    tokio::try_join!(src_to_dst, dst_to_src)
+        // discard the `Ok(_)` value as it's useless
+        .map(|_| ())
 }
 
 // wait for src to be readable
 // splice from src to the pipe buffer
 // wait for dst to be writable
 // splice to dst from the pipe buffer
-async fn splice_copy(src: &mut ReadHalf<'_>, dst: &mut WriteHalf<'_>) -> io::Result<()> {
+async fn splice_copy(src: &mut ReadHalf<'_>, dst: &mut WriteHalf<'_>) -> Result<()> {
     use std::io::{Error, ErrorKind::WouldBlock};
 
-    let pipe = Pipe::new()?;
+    let pipe = Pipe::new().wrap_err("failed to create pipe")?;
+    // number of bytes that the pipe buffer is currently holding
     let mut size = 0;
     let mut done = false;
 
@@ -108,8 +139,10 @@ async fn splice_copy(src: &mut ReadHalf<'_>, dst: &mut WriteHalf<'_>) -> io::Res
     let src_fd = src.as_raw_fd();
     let dst_fd = dst.as_raw_fd();
 
-    'LOOP: while !done {
-        src.readable().await?;
+    while !done {
+        src.readable()
+            .await
+            .wrap_err("awaiting on readable failed")?;
         let ret = src.try_io(Interest::READABLE, || {
             while size < PIPE_BUF_SIZE {
                 match splice(src_fd, pipe.w, PIPE_BUF_SIZE - size) {
@@ -128,11 +161,13 @@ async fn splice_copy(src: &mut ReadHalf<'_>, dst: &mut WriteHalf<'_>) -> io::Res
         });
         if let Err(err) = ret {
             if err.kind() != WouldBlock {
-                break 'LOOP;
+                break;
             }
         }
 
-        dst.writable().await?;
+        dst.writable()
+            .await
+            .wrap_err("awaiting on writable failed")?;
         let ret = dst.try_io(Interest::WRITABLE, || {
             while size > 0 {
                 match splice(pipe.r, dst_fd, size) {
@@ -145,10 +180,9 @@ async fn splice_copy(src: &mut ReadHalf<'_>, dst: &mut WriteHalf<'_>) -> io::Res
             }
             Ok(())
         });
-
         if let Err(err) = ret {
             if err.kind() != WouldBlock {
-                break 'LOOP;
+                break;
             }
         }
     }
@@ -156,6 +190,6 @@ async fn splice_copy(src: &mut ReadHalf<'_>, dst: &mut WriteHalf<'_>) -> io::Res
     if done {
         Ok(())
     } else {
-        Err(Error::last_os_error())
+        Err(Error::last_os_error().into())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,6 @@ async fn main() {
     };
 
     if let Err(why) = ret {
-        log::error!("{why}");
+        log::error!("{why:#}");
     }
 }


### PR DESCRIPTION
This PR introduces context messages for each error message, providing additional information to help understand the cause of the error. Here's an example before/after:

Before:
```
[2023-01-02T13:15:03Z INFO  mmproxy::listener::tcp] listening on: 127.0.0.1:25577
[2023-01-02T13:15:06Z INFO  mmproxy::listener::tcp] [new conn] [origin: 127.0.0.1:53566 [src: 127.0.0.1:0]
[2023-01-02T13:15:06Z ERROR mmproxy::listener::tcp] while handling a connection: Operation not permitted (os error 1)
```
After:
```
[2023-01-02T13:12:59Z INFO  mmproxy::listener::tcp] listening on: 127.0.0.1:25577
[2023-01-02T13:13:16Z INFO  mmproxy::listener::tcp] [new conn] [origin: 127.0.0.1:46780] [src: 127.0.0.1:0]
[2023-01-02T13:13:16Z ERROR mmproxy::listener::tcp] failed to set ip transparent on the upstream socket: Operation not permitted (os error 1)
```